### PR TITLE
Small changes - cmd command instead of bash

### DIFF
--- a/docs/deploymentGuide.md
+++ b/docs/deploymentGuide.md
@@ -115,10 +115,10 @@ Moreover, you will need to upload your github username to Amazon SSM Parameter S
 <summary>macOS</summary>
 
 ```bash
-aws ssm put-parameter ^
-    --name "Lat-owner-name" ^
-    --value "<YOUR-GITHUB-USERNAME>" ^
-    --type String ^
+aws ssm put-parameter \
+    --name "Lat-owner-name" \
+    --value "<YOUR-GITHUB-USERNAME>" \
+    --type String \
     --profile <YOUR-PROFILE-NAME>
 ```
 </details>
@@ -188,7 +188,7 @@ aws secretsmanager create-secret `
 
 &nbsp;
 
-For example,
+For example (macOS),
 
 ```
 aws secretsmanager create-secret \


### PR DESCRIPTION
One of the mac0S systems manager commands in the deployment guide was written in windows cmd with '^' instead of using the bash equivalent '/', small change.