### PR TITLE
Potential fix for code scanning alert no. 7: Clear-text logging of sensitive information

### DIFF
--- a/cdk/lambda/text_generation/src/main.py
+++ b/cdk/lambda/text_generation/src/main.py
@@ -48,7 +48,7 @@ def get_secret(secret_name, expect_json=True):
             logger.error(f"Failed to decode JSON for secret {secret_name}: {e}")
             raise ValueError(f"Secret {secret_name} is not properly formatted as JSON.")
         except Exception as e:
-            logger.error(f"Error fetching secret {secret_name}: {e}")
+            logger.error("Error fetching secret. Please check the system logs for more details.")
             raise
     return db_secret
 


### PR DESCRIPTION
Potential fix for [https://github.com/UBC-CIC/Legal-Aid-Tool/security/code-scanning/7](https://github.com/UBC-CIC/Legal-Aid-Tool/security/code-scanning/7)

To fix the issue, we should avoid logging sensitive information such as `secret_name` and the error message `e` directly. Instead, we can log a generic error message that does not include sensitive details. This ensures that sensitive data is not exposed in logs while still providing useful information for debugging.

The fix involves:
1. Replacing the logging statement on line 51 with a generic error message that does not include `secret_name` or `e`.
2. Optionally, if detailed error information is needed for debugging, it can be stored securely elsewhere (e.g., in a secure monitoring system) rather than being logged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
