### PR TITLE
Potential fix for code scanning alert no. 8: Incomplete multi-character sanitization

### DIFF
--- a/frontend/src/pages/CasePage/Transcriptions.jsx
+++ b/frontend/src/pages/CasePage/Transcriptions.jsx
@@ -348,7 +348,8 @@ const handleDownload = async (transcription) => {
   doc.text("Transcription:", margin, y);
   y += 10;
 
-  const content = marked.parse(audioText).replace(/<[^>]+>/g, "");
+  const sanitizedHtml = DOMPurify.sanitize(marked.parse(audioText));
+  const content = sanitizedHtml.replace(/<[^>]+>/g, "");
   const lines = doc.splitTextToSize(content, 180);
 
   for (let i = 0; i < lines.length; i++) {


### PR DESCRIPTION
Potential fix for [https://github.com/UBC-CIC/Legal-Aid-Tool/security/code-scanning/8](https://github.com/UBC-CIC/Legal-Aid-Tool/security/code-scanning/8)

To fix the issue, the sanitization of the parsed Markdown content should be done using a robust and well-tested library rather than relying on a custom regular expression. The `DOMPurify` library is already imported in the file and is specifically designed to sanitize HTML content effectively. By using `DOMPurify.sanitize()` on the parsed HTML from `marked.parse(audioText)`, we can ensure that all potentially harmful tags and attributes are removed. This eliminates the risk of injection vulnerabilities.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
