### PR TITLE
fixed instructor not authorized error during transcription upload

### DIFF
--- a/cdk/graphql/schema.graphql
+++ b/cdk/graphql/schema.graphql
@@ -15,7 +15,7 @@ type Mutation {
 type Subscription {
   onNotify(audioFileId: String!): Notification
     @aws_subscribe(mutations: ["sendNotification"])
-    @aws_auth(cognito_groups: ["student"])
+    @aws_auth(cognito_groups: ["student", "instructor"])
 }
 
 type Notification {


### PR DESCRIPTION
Allowed instructor to be authorized to real-time notifications, to avoid false error when adding audio transcriptions despite the transcription functionally being added.

